### PR TITLE
fix: add thumbnail attribution

### DIFF
--- a/_posts/2026-01-22-ie-benchmark-preprint.md
+++ b/_posts/2026-01-22-ie-benchmark-preprint.md
@@ -19,3 +19,5 @@ We evaluated the tools in terms of usability, accuracy, robustness, and privacy.
 %} 
 
 Special thanks goes to [Aaron Yu](/members/aaron-yu.html), who worked on this project as a summer student last year.
+
+*<sup>Thumbnail image generated using GPT-Image-1 (OpenAI)</sup>


### PR DESCRIPTION
add thumbnail attribution text to benchmark paper news item